### PR TITLE
IVE-196: unconditionally set GPIO values in regulator_gpio.c driver

### DIFF
--- a/dts/bindings/regulator/regulator-gpio.yaml
+++ b/dts/bindings/regulator/regulator-gpio.yaml
@@ -74,3 +74,8 @@ properties:
   startup-delay-us:
     type: int
     description: startup time in microseconds
+
+  no-readback:
+    type: boolean
+    description: |
+      GPIO does not support reading back output value.


### PR DESCRIPTION
 - Introduce new parameter that allows to unconditionally set GPIO values on systems that does not allow reading back GPIO configured for output.