### PR TITLE
net: l2 wifi shell: Fix crash if wifi iface is not up

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -603,6 +603,10 @@ static int cmd_wifi_scan(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (do_scan) {
+		if (!iface) {
+			shell_fprintf(sh, SHELL_ERROR, "No valid iface found\n");
+			return -ENODEV;
+		}
 		if (net_mgmt(NET_REQUEST_WIFI_SCAN, iface, &params, sizeof(params))) {
 			shell_fprintf(sh, SHELL_WARNING, "Scan request failed\n");
 			return -ENOEXEC;


### PR DESCRIPTION
net: l2 wifi shell: Fix crash if wifi iface is not up

CB24FW-134: Fix crash if wifi iface is not up

Signed-off-by: Dmitry Alexeev <dmitry.alexeev@emcraft.com>
